### PR TITLE
fix(auth): sign in and sign out password show hidden button fixed

### DIFF
--- a/apps/edust/src/features/authentication/sign-in.tsx
+++ b/apps/edust/src/features/authentication/sign-in.tsx
@@ -73,7 +73,7 @@ export const SignIn: React.FC = () => {
             variant: "success",
             title: data?.message,
           })
-          
+
           dispatch(
             setAuthentication({
               isAuthenticated: true,
@@ -169,20 +169,26 @@ export const SignIn: React.FC = () => {
                       </Link>
                     </div>
                     <FormControl>
-                      <div className="realative">
+                      <div className="relative">
                         <Input
                           type={isPasswordVisible ? "text" : "password"}
                           placeholder="********"
-                          icon={isPasswordVisible ? <FaEye /> : <FaEyeSlash />}
-                          onIconClick={onVisibilityClick}
                           {...field}
                         />
+                        <button
+                          type="button"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-500"
+                          onClick={onVisibilityClick}
+                        >
+                          {isPasswordVisible ? <FaEye /> : <FaEyeSlash />}
+                        </button>
                       </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
               <Button type="submit" className="w-full" disabled={isLoading}>
                 {isLoading ? <BarLoader color="#fff" /> : "Sign In"}
               </Button>

--- a/apps/edust/src/features/authentication/sign-up.tsx
+++ b/apps/edust/src/features/authentication/sign-up.tsx
@@ -157,13 +157,20 @@ export const SignUp: React.FC = () => {
                     <FormItem>
                       <FormLabel>Password</FormLabel>
                       <FormControl>
-                        <Input
-                          type={isPasswordVisible ? "text" : "password"}
-                          placeholder="********"
-                          icon={isPasswordVisible ? <FaEye /> : <FaEyeSlash />}
-                          onIconClick={onVisibilityClick}
-                          {...field}
-                        />
+                        <div className="relative">
+                          <Input
+                            type={isPasswordVisible ? "text" : "password"}
+                            placeholder="********"
+                            {...field}
+                          />
+                          <button
+                            type="button"
+                            className="absolute right-3 top-1/2 -translate-y-1/2 transform text-gray-500"
+                            onClick={onVisibilityClick}
+                          >
+                            {isPasswordVisible ? <FaEye /> : <FaEyeSlash />}
+                          </button>
+                        </div>
                       </FormControl>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
It has resolved a bug in the password visibility toggle feature of the Sign-In and sign-out component in the Edust open-source project. Previously, the onIconClick event was ignored due to its unsupported implementation in the Input component. The fix involves replacing the unsupported event handler with a properly styled and interactive button for toggling password visibility. This ensures a better user experience and eliminates React warnings.